### PR TITLE
feat: make category directory by components directory

### DIFF
--- a/data/categories.ts
+++ b/data/categories.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "fs"
 import path from "path"
-import { convertCase, getDirNames } from "data/components"
 import type { CategoriesGroup } from "data/types"
+import { toKebabCase } from "utils/assetion"
+import { getDirNames } from "utils/contentlayer"
 // import images from './images';
 
 const contentsDir = path.join(process.cwd(), "contents")
@@ -45,7 +46,7 @@ export const getComponentsByCategory = async (category: string) => {
 
     return {
       component: `${category}/${componentName}`,
-      slug: convertCase(`${category}/${componentName}`),
+      slug: toKebabCase(`${category}/${componentName}`),
       attributes: metadata,
       code: code,
     }

--- a/data/categories.ts
+++ b/data/categories.ts
@@ -52,8 +52,5 @@ export const getComponentsByCategory = async (category: string) => {
     }
   })
 
-  const results = await Promise.all(promises)
-
-  // NOTE: このfilterはなんや？（undefinedのやつとか入ってくる？）
-  return results.filter((c) => c)
+  return await Promise.all(promises)
 }

--- a/data/categories.ts
+++ b/data/categories.ts
@@ -11,7 +11,6 @@ export const ALL_CATEGORIES = getDirNames(contentsDir).map((category) => ({
   name: category.charAt(0).toUpperCase() + category.slice(1),
 }))
 
-// TODO: nameもディレクトリ構造に反映するか
 export const CATEGORIES: CategoriesGroup[] = [
   {
     name: "Application UI",

--- a/data/categories.ts
+++ b/data/categories.ts
@@ -1,54 +1,58 @@
-import type { CategoriesGroup, Category } from "./types"
+import { readFileSync } from "fs"
+import path from "path"
+import { convertCase, getDirNames } from "data/components"
+import type { CategoriesGroup } from "data/types"
 // import images from './images';
 
+const contentsDir = path.join(process.cwd(), "contents")
+export const ALL_CATEGORIES = getDirNames(contentsDir).map((category) => ({
+  slug: category,
+  name: category.charAt(0).toUpperCase() + category.slice(1),
+}))
+
+// TODO: nameもディレクトリ構造に反映するか
 export const CATEGORIES: CategoriesGroup[] = [
   {
     name: "Application UI",
-    categories: [
-      { slug: "navbars", name: "Navbars" },
-      { slug: "headers", name: "Headers" },
-      { slug: "footers", name: "Footers" },
-      { slug: "grids", name: "Grids" },
-      { slug: "users", name: "User info and controls" },
-      { slug: "inputs", name: "Inputs" },
-      { slug: "buttons", name: "Buttons" },
-      { slug: "sliders", name: "Sliders" },
-      { slug: "dropzones", name: "Dropzones" },
-      { slug: "app-cards", name: "Application cards" },
-      { slug: "stats", name: "Stats" },
-      { slug: "tables", name: "Tables" },
-      { slug: "dnd", name: "Drag'n'Drop" },
-      { slug: "carousels", name: "Carousels" },
-    ],
-  },
-  {
-    name: "Page sections",
-    categories: [
-      { slug: "hero", name: "Hero headers" },
-      { slug: "features", name: "Features section" },
-      { slug: "authentication", name: "Authentication" },
-      { slug: "faq", name: "Frequently asked questions" },
-      { slug: "contact", name: "Contact us section" },
-      { slug: "error-pages", name: "Error pages" },
-      { slug: "banners", name: "Banners" },
-    ],
-  },
-  {
-    name: "Blog UI",
-    categories: [
-      { slug: "article-cards", name: "Article cards" },
-      { slug: "toc", name: "Table of contents" },
-      { slug: "comments", name: "Comments" },
-    ],
+    categories: ALL_CATEGORIES,
   },
 ]
-
-const ALL_CATEGORIES = CATEGORIES.reduce<Category[]>((acc, group) => {
-  acc.push(...group.categories)
-  return acc
-}, [])
 
 export const CATEGORIES_SLUGS = ALL_CATEGORIES.map((item) => item.slug)
 
 export const getCategoryData = (category: string) =>
   ALL_CATEGORIES.find((item) => item.slug === category)
+
+export const getComponentsByCategory = async (category: string) => {
+  const root = path.join(contentsDir, category)
+  const components = getDirNames(root)
+  const promises = components.map(async (componentName: string) => {
+    const { metadata } = await import(
+      `../contents/${category}/${componentName}/index`
+    )
+
+    const filePath = path.join(root, componentName, "index.tsx")
+
+    const fileContent = readFileSync(filePath, "utf8")
+    const index = fileContent
+      .split("\n")
+      .findIndex((v) => /export\s+const\s+metadata\s*=\s*{/.test(v))
+    const code = fileContent
+      .split("\n")
+      .slice(0, index)
+      .filter((line) => !line.includes("export"))
+      .join("\n")
+
+    return {
+      component: `${category}/${componentName}`,
+      slug: convertCase(`${category}/${componentName}`),
+      attributes: metadata,
+      code: code,
+    }
+  })
+
+  const results = await Promise.all(promises)
+
+  // NOTE: このfilterはなんや？（undefinedのやつとか入ってくる？）
+  return results.filter((c) => c)
+}

--- a/data/components.ts
+++ b/data/components.ts
@@ -1,5 +1,7 @@
 import { readFileSync, readdirSync } from "fs"
 import path from "path"
+import { toKebabCase } from "utils/assetion"
+import { getDirNames } from "utils/contentlayer"
 
 export type ComponentInfo = {
   component: string
@@ -7,15 +9,6 @@ export type ComponentInfo = {
   code: string
   // code: { fileName: string; language: string; code: string }[];
   attributes: any
-}
-
-// TODO: utilsに欲しい
-export const convertCase = (string: string) => {
-  const splitted = string
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .toLowerCase()
-    .split(" ")
-  return splitted.join("-")
 }
 
 // const getComponentCode = (componentFolder: string, componentName: string) => {
@@ -52,11 +45,6 @@ export const convertCase = (string: string) => {
 // }
 
 // TODO: utilsに欲しい
-export const getDirNames = (basePath: string) => {
-  return readdirSync(basePath, { withFileTypes: true })
-    .filter((dir) => dir.isDirectory())
-    .map((dir) => dir.name)
-}
 
 export const getPaths = () => {
   const result: { params: { slug: string[] } }[] = []
@@ -106,7 +94,7 @@ export const getAllComponents = async (): Promise<ComponentInfo[]> => {
 
     return {
       component: componentName,
-      slug: convertCase(componentName),
+      slug: toKebabCase(componentName),
       attributes: metadata,
       code: code,
     }

--- a/data/components.ts
+++ b/data/components.ts
@@ -9,7 +9,8 @@ export type ComponentInfo = {
   attributes: any
 }
 
-const convertCase = (string: string) => {
+// TODO: utilsに欲しい
+export const convertCase = (string: string) => {
   const splitted = string
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .toLowerCase()
@@ -50,7 +51,8 @@ const convertCase = (string: string) => {
 //   ]
 // }
 
-const getDirNames = (basePath: string) => {
+// TODO: utilsに欲しい
+export const getDirNames = (basePath: string) => {
   return readdirSync(basePath, { withFileTypes: true })
     .filter((dir) => dir.isDirectory())
     .map((dir) => dir.name)

--- a/data/components.ts
+++ b/data/components.ts
@@ -44,8 +44,6 @@ export type ComponentInfo = {
 //   ]
 // }
 
-// TODO: utilsに欲しい
-
 export const getPaths = () => {
   const result: { params: { slug: string[] } }[] = []
   const root = path.join(process.cwd(), "contents")

--- a/pages/category/[category].page.tsx
+++ b/pages/category/[category].page.tsx
@@ -23,8 +23,6 @@ type PageProps = {
   data: {
     category: Category | undefined
     components: ComponentInfo[]
-    // TODO: allComponentsいらない?
-    // allComponents: ComponentInfo[]
   }
 }
 
@@ -45,8 +43,6 @@ export const getStaticProps: GetStaticProps<PageProps, PageParams> = async (
   const data: PageProps["data"] = {
     category: getCategoryData(ctx!.params!.category),
     components: await getComponentsByCategory(ctx!.params!.category),
-    // TODO: allComponentsいらない?
-    // allComponents: await getAllComponents(),
   }
   return {
     props: { data },

--- a/pages/category/[category].page.tsx
+++ b/pages/category/[category].page.tsx
@@ -10,9 +10,12 @@ import {
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next"
 import { ComponentPreview } from "components/layouts"
 import { useI18n } from "contexts/i18n-context"
-import { CATEGORIES_SLUGS, getCategoryData } from "data/categories"
+import {
+  CATEGORIES_SLUGS,
+  getCategoryData,
+  getComponentsByCategory,
+} from "data/categories"
 import type { ComponentInfo } from "data/components"
-import { getAllComponents, getComponentsByCategory } from "data/components"
 import type { Category } from "data/types"
 import { AppLayout } from "layouts/app-layout"
 
@@ -20,7 +23,8 @@ type PageProps = {
   data: {
     category: Category | undefined
     components: ComponentInfo[]
-    allComponents: ComponentInfo[]
+    // TODO: allComponentsいらない?
+    // allComponents: ComponentInfo[]
   }
 }
 
@@ -28,22 +32,21 @@ type PageParams = ParsedUrlQuery & {
   category: string
 }
 
-export const getStaticPaths: GetStaticPaths = async () => ({
-  paths: CATEGORIES_SLUGS.map((slug) => ({ params: { category: slug } })),
-  fallback: false,
-})
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: CATEGORIES_SLUGS.map((slug) => ({ params: { category: slug } })),
+    fallback: false,
+  }
+}
 
 export const getStaticProps: GetStaticProps<PageProps, PageParams> = async (
-  context,
+  ctx,
 ) => {
-  const components = await getComponentsByCategory()
   const data: PageProps["data"] = {
-    category: getCategoryData(context!.params!.category),
-    components:
-      context!.params!.category in components
-        ? components[context!.params!.category]
-        : [],
-    allComponents: await getAllComponents(),
+    category: getCategoryData(ctx!.params!.category),
+    components: await getComponentsByCategory(ctx!.params!.category),
+    // TODO: allComponentsいらない?
+    // allComponents: await getAllComponents(),
   }
   return {
     props: { data },

--- a/utils/assetion.ts
+++ b/utils/assetion.ts
@@ -1,0 +1,7 @@
+export const toKebabCase = (string: string) => {
+  const splitted = string
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(" ")
+  return splitted.join("-")
+}

--- a/utils/contentlayer.ts
+++ b/utils/contentlayer.ts
@@ -1,0 +1,6 @@
+import { readdirSync } from "fs"
+
+export const getDirNames = (basePath: string) =>
+  readdirSync(basePath, { withFileTypes: true })
+    .filter((dir) => dir.isDirectory())
+    .map((dir) => dir.name)


### PR DESCRIPTION
Closes #11 

## Description
コンポーネントのディレクトリ構造からカテゴリページのパスを生成

## Current behavior (updates)
`data/categories.ts`に直書きしてある`CATEGORIES`を参照してページのパスを生成

## New behavior
`contents`配下のパスをパースしてページのパスを生成
