### PR TITLE
Added `i18n`

### DIFF
--- a/components/data-display/categories-display.tsx
+++ b/components/data-display/categories-display.tsx
@@ -2,6 +2,7 @@ import { Link as UILink, List, ListItem, Text, Heading } from "@yamada-ui/react"
 import Link from "next/link"
 import type { FC } from "react"
 import { ComponentPreview } from "components/layouts"
+import { useI18n } from "contexts/i18n-context"
 
 type CategoriesDisplayProps = {
   data: {
@@ -17,11 +18,16 @@ export const CategoriesDisplay: FC<CategoriesDisplayProps> = ({
   categoryDir,
   data,
 }) => {
+  const { t } = useI18n()
+
   return (
     <>
-      <Heading>カテゴリー：{categoryDir}</Heading>
+      <Heading>
+        {t("categories.heading")}
+        {categoryDir}
+      </Heading>
       <List>
-        {data.map((e, i) => (
+        {data.filter(Boolean).map((e, i) => (
           <ListItem key={`${e.slug}-${i}`} display="flex" flexDir="column">
             <Text>{e.slug}</Text>
             <UILink as={Link} href={`/${e.slug}`}>{`/${e.slug}`}</UILink>

--- a/components/data-display/categories-group-display.tsx
+++ b/components/data-display/categories-group-display.tsx
@@ -14,6 +14,8 @@ export const CategoriesGroupDisplay: FC<CategoriesGroupDisplayProps> = ({
   categories,
   documentTypeName,
 }) => {
+  if (!categories) return null
+
   return (
     <>
       <Heading>{documentTypeName}</Heading>

--- a/contents/application-ui/headers/header-2/index.ja.tsx
+++ b/contents/application-ui/headers/header-2/index.ja.tsx
@@ -6,14 +6,14 @@ const Header: FC = () => {
   return (
     <HStack as="header" justify="space-between">
       <Box>
-        <Heading>Icon</Heading>
+        <Heading>アイコン</Heading>
       </Box>
       <HStack>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
       </HStack>
     </HStack>
   )
@@ -22,6 +22,6 @@ const Header: FC = () => {
 export default Header
 
 export const metadata: ComponentMetadata = {
-  title: "Simple Header",
-  description: "This is simple header component.",
+  title: "シンプルなヘッダー2",
+  description: "これはシンプルなヘッダーコンポーネント2です",
 }

--- a/contents/application-ui/headers/header-2/index.tsx
+++ b/contents/application-ui/headers/header-2/index.tsx
@@ -6,14 +6,14 @@ const Header2: FC = () => {
   return (
     <HStack as="header" justify="space-between">
       <Box>
-        <Heading>アイコン</Heading>
+        <Heading>Icon</Heading>
       </Box>
       <HStack>
-        <Link href="/">リンク</Link>
-        <Link href="/">リンク</Link>
-        <Link href="/">リンク</Link>
-        <Link href="/">リンク</Link>
-        <Link href="/">リンク</Link>
+        <Link href="/">Link</Link>
+        <Link href="/">Link</Link>
+        <Link href="/">Link</Link>
+        <Link href="/">Link</Link>
+        <Link href="/">Link</Link>
       </HStack>
     </HStack>
   )

--- a/contents/application-ui/headers/header/index.ja.tsx
+++ b/contents/application-ui/headers/header/index.ja.tsx
@@ -6,14 +6,14 @@ const Header: FC = () => {
   return (
     <HStack as="header" justify="space-between">
       <Box>
-        <Heading>Icon</Heading>
+        <Heading>アイコン</Heading>
       </Box>
       <HStack>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
-        <Link href="/">Link</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
+        <Link href="/">リンク</Link>
       </HStack>
     </HStack>
   )
@@ -22,6 +22,6 @@ const Header: FC = () => {
 export default Header
 
 export const metadata: ComponentMetadata = {
-  title: "Simple Header",
-  description: "This is simple header component.",
+  title: "シンプルなヘッダー",
+  description: "これはシンプルなヘッダーコンポーネントです",
 }

--- a/i18n/ui.en.json
+++ b/i18n/ui.en.json
@@ -30,7 +30,8 @@
   },
   "categories": {
     "title": "Yamada Components",
-    "description": ""
+    "description": "",
+    "heading": "Categories: "
   },
   "components": {
     "title": "Yamada Components",

--- a/i18n/ui.ja.json
+++ b/i18n/ui.ja.json
@@ -30,7 +30,8 @@
   },
   "categories": {
     "title": "Yamada Components",
-    "description": ""
+    "description": "",
+    "heading": "カテゴリー："
   },
   "components": {
     "title": "Yamada Components",

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -1,6 +1,7 @@
-import { readFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync, readdirSync } from "fs"
 import path from "path"
 import { toKebabCase } from "@yamada-ui/react"
+import { CONSTANT } from "constant"
 import type { ComponentInfo } from "types"
 
 // const getComponentCode = (componentFolder: string, componentName: string) => {
@@ -42,56 +43,95 @@ export const getDirNames = (basePath: string) => {
     .map((dir) => dir.name)
 }
 
-export const getPaths = (documentTypeName: string) => {
-  const result: { params: { slug: string[] } }[] = []
+export const getPaths = ({
+  documentTypeName,
+  locales,
+}: {
+  documentTypeName: string
+  locales: string[]
+}) => {
+  const defaultLocale = CONSTANT.I18N.DEFAULT_LOCALE
+  const result: { params: { slug: string[] }; locale?: string }[] = []
   const root = path.join(process.cwd(), "contents", documentTypeName)
   const parent = getDirNames(root)
-  result.push({ params: { slug: [] } })
+  for (const locale of locales || []) {
+    result.push({ params: { slug: [] }, locale })
+  }
   for (const item of parent) {
     const parentFullPath = path.join(root, item)
-    result.push({ params: { slug: [item] } })
     readdirSync(parentFullPath, { withFileTypes: true })
       .filter((dir) => dir.isDirectory())
       .forEach((r) => {
-        result.push({ params: { slug: [item, r.name] } })
+        const dirPath = path.join(parentFullPath, r.name)
+        const files = readdirSync(dirPath)
+        for (const file of files) {
+          const match = file.match(/index(?:\.(.+))?\.tsx$/)
+          if (match) {
+            const locale = match[1] || defaultLocale
+            if (locales.includes(locale)) {
+              result.push({ params: { slug: [item] }, locale })
+              result.push({ params: { slug: [item, r.name] }, locale })
+            }
+          }
+        }
       })
   }
-
   return result
 }
 
 export const getComponent = async (
   documentTypeName: string,
   componentDir: string,
+  locale: string,
 ) => {
-  const { metadata } = await import(
-    `../contents/${documentTypeName}/${componentDir}/index`
-  )
-  const filePath = path.join(
-    process.cwd(),
-    "contents",
-    documentTypeName,
-    componentDir,
-    "index.tsx",
-  )
+  try {
+    let filename = `index${
+      locale !== CONSTANT.I18N.DEFAULT_LOCALE ? `.${locale}` : ""
+    }`
 
-  const fileContent = readFileSync(filePath, "utf8")
-  const index = fileContent
-    .split("\n")
-    .findIndex((v) => /export\s+const\s+metadata\s*=\s*{/.test(v))
+    let filePath = path.join(
+      process.cwd(),
+      "contents",
+      documentTypeName,
+      componentDir,
+      `${filename}.tsx`,
+    )
 
-  const data = {
-    path: `${documentTypeName}/${componentDir}/index.tsx`,
-    component: fileContent
+    if (!existsSync(filePath)) {
+      filename = "index"
+      filePath = path.join(
+        process.cwd(),
+        "contents",
+        documentTypeName,
+        componentDir,
+        `${filename}.tsx`,
+      )
+    }
+
+    const { metadata } = await import(
+      `../contents/${documentTypeName}/${componentDir}/${filename}`
+    )
+
+    const fileContent = readFileSync(filePath, "utf8")
+    const index = fileContent
       .split("\n")
-      .slice(0, index)
-      .filter((line) => !line.includes("export"))
-      .join("\n"),
-    metadata,
-    slug: toKebabCase(`${documentTypeName}/${componentDir}`),
-  }
+      .findIndex((v) => /export\s+const\s+metadata\s*=\s*{/.test(v))
 
-  return data
+    const data = {
+      path: `${documentTypeName}/${componentDir}/${filename}.tsx`,
+      component: fileContent
+        .split("\n")
+        .slice(0, index)
+        .filter((line) => !line.includes("export"))
+        .join("\n"),
+      metadata,
+      slug: toKebabCase(`${documentTypeName}/${componentDir}`),
+    }
+
+    return data
+  } catch (error) {
+    return null
+  }
 }
 
 export const getAllComponents = async (): Promise<ComponentInfo[]> => {
@@ -139,26 +179,36 @@ export const getAllComponents = async (): Promise<ComponentInfo[]> => {
 export const getComponentsByCategory = async (
   documentTypeName: string,
   category: string,
+  locale: string,
 ) => {
-  const contentsDir = path.join(process.cwd(), "contents")
-  const root = path.join(contentsDir, documentTypeName, category)
-  const components = getDirNames(root)
-  const promises = components.map(async (componentName: string) => {
-    const data = await getComponent(
-      documentTypeName,
-      category + "/" + componentName,
-    )
+  try {
+    const contentsDir = path.join(process.cwd(), "contents")
+    const root = path.join(contentsDir, documentTypeName, category)
+    const components = getDirNames(root)
+    const promises = components.map(async (componentName: string) => {
+      const data = await getComponent(
+        documentTypeName,
+        category + "/" + componentName,
+        locale,
+      )
 
-    return data
-  })
+      return data
+    })
 
-  return await Promise.all(promises)
+    return await Promise.all(promises)
+  } catch (error) {
+    return null
+  }
 }
 
 export const getCategoriesByDocName = (documentTypeName: string) => {
-  const root = path.join(process.cwd(), "contents", documentTypeName)
-  return getDirNames(root).map((child) => ({
-    name: child,
-    slug: toKebabCase(path.join(documentTypeName, child)),
-  }))
+  try {
+    const root = path.join(process.cwd(), "contents", documentTypeName)
+    return getDirNames(root).map((child) => ({
+      name: child,
+      slug: toKebabCase(path.join(documentTypeName, child)),
+    }))
+  } catch (error) {
+    return null
+  }
 }

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -59,6 +59,9 @@ export const getPaths = ({
   }
   for (const item of parent) {
     const parentFullPath = path.join(root, item)
+    for (const locale of locales || []) {
+      result.push({ params: { slug: [item] }, locale })
+    }
     readdirSync(parentFullPath, { withFileTypes: true })
       .filter((dir) => dir.isDirectory())
       .forEach((r) => {
@@ -69,7 +72,6 @@ export const getPaths = ({
           if (match) {
             const locale = match[1] || defaultLocale
             if (locales.includes(locale)) {
-              result.push({ params: { slug: [item] }, locale })
               result.push({ params: { slug: [item, r.name] }, locale })
             }
           }

--- a/utils/next.ts
+++ b/utils/next.ts
@@ -20,17 +20,23 @@ export const getServerSideCommonProps = async ({
 
 export const getStaticDocumentPaths =
   (documentTypeName: string) =>
-  async ({}: GetStaticPathsContext) => {
-    const paths = getPaths(documentTypeName)
+  async ({ locales }: GetStaticPathsContext) => {
+    const paths = getPaths({ documentTypeName, locales })
 
-    return { paths, fallback: false }
+    return { paths, fallback: true }
   }
 
 export const getStaticDocumentProps =
   (documentTypeName: string) =>
-  async ({ params }: GetStaticPropsContext) => {
+  async ({ params, locale }: GetStaticPropsContext) => {
     if (!params.slug) {
       const categories = getCategoriesByDocName(documentTypeName)
+
+      if (!categories)
+        return {
+          notFound: true,
+        }
+
       return {
         props: {
           type: "categories-group",
@@ -43,7 +49,12 @@ export const getStaticDocumentProps =
     if ((params.slug as string[]).length > 1) {
       const componentDir = (params.slug as string[]).join("/").toLowerCase()
 
-      const data = await getComponent(documentTypeName, componentDir)
+      const data = await getComponent(documentTypeName, componentDir, locale)
+
+      if (!data)
+        return {
+          notFound: true,
+        }
 
       return {
         props: {
@@ -54,7 +65,16 @@ export const getStaticDocumentProps =
     } else {
       // params.slugの0番目のデータのカテゴリ内のコンポーネント一覧を取得
       const categoryDir = (params.slug as string[])[0].toLowerCase()
-      const data = await getComponentsByCategory(documentTypeName, categoryDir)
+      const data = await getComponentsByCategory(
+        documentTypeName,
+        categoryDir,
+        locale,
+      )
+
+      if (!data)
+        return {
+          notFound: true,
+        }
 
       return {
         props: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #30

## Description

Added `i18n` and `index.ja.tsx` support.

## Current behavior (updates)

`i18n` did not work properly in component pages.

## New behavior

Make `i18n` work and allow multi-language components.

## Is this a breaking change (Yes/No):

No

## Additional Information

### Discussion required

Should we have one `object` that would have all metadata for all languages? If so, should we prioritise the `metadata` if it already exists in `index.ja.tsx`?