### PR TITLE
Translated category and component counts

### DIFF
--- a/components/data-display/category-card.tsx
+++ b/components/data-display/category-card.tsx
@@ -9,6 +9,7 @@ import type { LinkBoxProps, TextProps } from "@yamada-ui/react"
 import Link from "next/link"
 import { memo } from "react"
 import type { ComponentCategoryGroup } from "component"
+import { useI18n } from "contexts/i18n-context"
 
 export type CategoryCardProps = LinkBoxProps &
   Pick<ComponentCategoryGroup, "title" | "items" | "slug"> & {
@@ -18,6 +19,7 @@ export type CategoryCardProps = LinkBoxProps &
 export const CategoryCard = memo(
   forwardRef<CategoryCardProps, "article">(
     ({ title, slug, items, headingProps, ...rest }, ref) => {
+      const { tc } = useI18n()
       return (
         <LinkBox
           ref={ref}
@@ -33,7 +35,11 @@ export const CategoryCard = memo(
             </Text>
 
             <Text color="muted" fontSize="sm">
-              {items.length} components
+              {tc("component.category.count", (str) => (
+                <Text as="span" key={str}>
+                  {str === "count" ? items?.length ?? 0 : str}
+                </Text>
+              ))}
             </Text>
           </VStack>
 

--- a/components/data-display/category-group.tsx
+++ b/components/data-display/category-group.tsx
@@ -10,7 +10,7 @@ export type CategoryGroupProps = {}
 
 export const CategoryGroup: FC = memo(() => {
   const { categoryGroup } = useApp()
-  const { t } = useI18n()
+  const { t, tc } = useI18n()
 
   return (
     <>
@@ -24,7 +24,13 @@ export const CategoryGroup: FC = memo(() => {
           {categoryGroup.title}
         </Heading>
 
-        <Text color="muted">{categoryGroup.items?.length ?? 0} categories</Text>
+        <Text color="muted">
+          {tc("component.category-group.count", (str) => (
+            <Text as="span" key={str}>
+              {str === "count" ? categoryGroup.items?.length ?? 0 : str}
+            </Text>
+          ))}
+        </Text>
       </HStack>
 
       <Grid as="nav" templateColumns={{ base: "repeat(4, 1fr)" }} gap="md">

--- a/components/data-display/category.tsx
+++ b/components/data-display/category.tsx
@@ -10,7 +10,7 @@ export type CategoryProps = {}
 
 export const Category: FC = memo(() => {
   const { categoryGroup, category } = useApp()
-  const { t } = useI18n()
+  const { t, tc } = useI18n()
 
   return (
     <>
@@ -24,7 +24,13 @@ export const Category: FC = memo(() => {
           {category.title}
         </Heading>
 
-        <Text color="muted">{category.items?.length ?? 0} categories</Text>
+        <Text color="muted">
+          {tc("component.category.count", (str) => (
+            <Text as="span" key={str}>
+              {str === "count" ? category.items?.length ?? 0 : str}
+            </Text>
+          ))}
+        </Text>
       </HStack>
 
       <VStack as="nav" gap="lg">

--- a/i18n/ui.en.json
+++ b/i18n/ui.en.json
@@ -38,10 +38,12 @@
       }
     },
     "category-group": {
-      "back-to": "Back to all category groups"
+      "back-to": "Back to all category groups",
+      "count": "`count` categories"
     },
     "category": {
-      "back-to": "Back to all categories"
+      "back-to": "Back to all categories",
+      "count": "`count` components"
     },
     "footer": {
       "description": "Built by `Hirotomo Yamada` and `these awesome people`"

--- a/i18n/ui.ja.json
+++ b/i18n/ui.ja.json
@@ -38,10 +38,12 @@
       }
     },
     "category-group": {
-      "back-to": "すべてのカテゴリグループに戻る"
+      "back-to": "すべてのカテゴリグループに戻る",
+      "count": "`count`個のカテゴリー"
     },
     "category": {
-      "back-to": "すべてのカテゴリに戻る"
+      "back-to": "すべてのカテゴリに戻る",
+      "count": "`count`個のコンポーネント"
     },
     "footer": {
       "description": "このアプリケーションは、`Hirotomo Yamada`と`愉快な仲間たち`によって開発されました。"

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -12,7 +12,7 @@ export const getStaticProps = getStaticCommonProps
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>
 
 const Page: NextPage<PageProps> = ({ componentTree }) => {
-  const { t } = useI18n()
+  const { t, tc } = useI18n()
 
   return (
     <AppProvider {...{ componentTree }}>
@@ -35,7 +35,13 @@ const Page: NextPage<PageProps> = ({ componentTree }) => {
                 </Heading>
               </Link>
 
-              <Text color="muted">{items?.length ?? 0} categories</Text>
+              <Text color="muted">
+                {tc("component.category-group.count", (str) => (
+                  <Text as="span" key={str}>
+                    {str === "count" ? items?.length ?? 0 : str}
+                  </Text>
+                ))}
+              </Text>
             </HStack>
 
             <Grid


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #96

## Description

I have translated component and category count to Japanese.

## Current behavior (updates)

In both languages, it said "... components/categories".

## New behavior

Now says "...個のコンポーネント/カテゴリー"

## Is this a breaking change (Yes/No):

No
