### PR TITLE
fix(error-pages): fixed the height of error-pages examples

### DIFF
--- a/contents/page-sections/error-pages/404-page/metadata.json
+++ b/contents/page-sections/error-pages/404-page/metadata.json
@@ -1,6 +1,11 @@
 {
   "en": { "title": "404 page", "description": "This is a 404 page." },
   "ja": { "title": "404ページ", "description": "このページは404ページです。" },
+  "options": {
+    "container": {
+      "centerContent": true
+    }
+  },
   "authors": [
     {
       "id": 61367823,

--- a/contents/page-sections/error-pages/500-page/index.tsx
+++ b/contents/page-sections/error-pages/500-page/index.tsx
@@ -2,7 +2,13 @@ import { Button, Heading, Text, VStack } from "@yamada-ui/react"
 
 const ServerError = () => {
   return (
-    <VStack alignItems="center" bg="primary" p="lg">
+    <VStack
+      justifyContent="center"
+      alignItems="center"
+      bg="primary"
+      p="lg"
+      h="full"
+    >
       <Text fontSize="9xl" fontWeight="bold" color="whiteAlpha.800">
         500
       </Text>

--- a/contents/page-sections/error-pages/with-image/metadata.json
+++ b/contents/page-sections/error-pages/with-image/metadata.json
@@ -7,6 +7,11 @@
     "title": "画像付きの404ページ",
     "description": "これは画像付きの404ページです。"
   },
+  "options": {
+    "container": {
+      "centerContent": true
+    }
+  },
   "authors": [
     {
       "id": 61367823,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #221

## Description

Fixed the height of error pages examples and also made them centre.

## Current behavior (updates)

Height was not fit properly and it was not centred vertically.

## New behavior

Fixes the background color height and centre examples.

## Is this a breaking change (Yes/No):

No