### PR TITLE
feat(search): add 404 display when search result is not found

### DIFF
--- a/pages/search/index.page.tsx
+++ b/pages/search/index.page.tsx
@@ -1,5 +1,5 @@
 import type { ParsedUrlQuery } from "querystring"
-import { isArray } from "@yamada-ui/react"
+import { isArray, isEmpty } from "@yamada-ui/react"
 import type {
   InferGetServerSidePropsType,
   NextPageWithConfig,
@@ -44,6 +44,12 @@ export const getServerSideProps = async ({
       hits.map(async ({ slug }) => getComponent(slug)(locale as Locale)),
     )
   ).filter(Boolean) as Component[]
+
+  if (isEmpty(components)) {
+    return {
+      notFound: true,
+    }
+  }
 
   const ui = getUI(locale as Locale)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #223

## Description

This PR makes the page display 404 when search result is not found.

## Current behavior (updates)

Showed empty result.

## New behavior

Shows 404.

## Is this a breaking change (Yes/No):

No

## Additional Information

I have not fixed the NextJS error when switching locale, and this is not allowing me to add a check to see if label query is there.