### PR TITLE
fix(tags): fixed the `reorder-tags` component example

### DIFF
--- a/contents/data-display/tags/reorder-tags/index.tsx
+++ b/contents/data-display/tags/reorder-tags/index.tsx
@@ -38,7 +38,7 @@ const CardWithReorderTags: FC = () => {
           gap="sm"
         >
           {tags.map((tag) => (
-            <ReorderItem key={tag} label={tag} w="fit-content">
+            <ReorderItem key={tag} value={tag} label={tag} w="fit-content">
               <Tag colorScheme={tag}>{tag}</Tag>
             </ReorderItem>
           ))}

--- a/contents/data-display/tags/reorder-tags/index.tsx
+++ b/contents/data-display/tags/reorder-tags/index.tsx
@@ -38,7 +38,7 @@ const CardWithReorderTags: FC = () => {
           gap="sm"
         >
           {tags.map((tag) => (
-            <ReorderItem key={tag} value={tag} w="fit-content">
+            <ReorderItem key={tag} label={tag} w="fit-content">
               <Tag colorScheme={tag}>{tag}</Tag>
             </ReorderItem>
           ))}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #248

## Description

This fixes the ts error below:
```
Property 'label' is missing in type '{ children: Element; key: string; value: string; w: "fit-content"; }' but required in type 'ReorderItemOptions'.ts(2741)
```

## Is this a breaking change (Yes/No):

No