### PR TITLE
add `announcement` component as `Banners` category.

### DIFF
--- a/contents/data-display/banners/announcement/index.tsx
+++ b/contents/data-display/banners/announcement/index.tsx
@@ -1,0 +1,33 @@
+import { Box, Link, CloseButton, HStack, Text } from "@yamada-ui/react"
+import type { FC } from "react"
+
+const Announcement: FC = () => {
+  return (
+    <Box
+      bgGradient="linear(to-l, #7928CA, #FF0080)"
+      w="full"
+      position="fixed"
+      top="0"
+      left="0"
+    >
+      <HStack justifyContent="space-between">
+        <Text
+          size="sm"
+          padding="10px"
+          color="white"
+          marginLeft="35%"
+          fontWeight="500"
+          isTruncated
+        >
+          Yamada UI Con 20xx is on June 7th in Online.{" "}
+          <Link href="#" color="white" fontWeight="bold">
+            Get your ticket →
+          </Link>
+        </Text>
+        <CloseButton color="white" marginRight="1%" />
+      </HStack>
+    </Box>
+  )
+}
+
+export default Announcement

--- a/contents/data-display/banners/announcement/metadata.json
+++ b/contents/data-display/banners/announcement/metadata.json
@@ -1,0 +1,11 @@
+{
+  "en": {
+    "title": "Announcement",
+    "description": "A component to display announcement for event."
+  },
+  "ja": {
+    "title": "Announcement",
+    "description": "イベントのアナウンスを表示するコンポーネント"
+  },
+  "options": { "container": { "centerContent": true, "p": "md" } }
+}


### PR DESCRIPTION
Closes #252 

## Description
add `announcement` component as `Banners` category.

<img width="1418" alt="スクリーンショット 2024-06-25 午前5 19 22" src="https://github.com/yamada-ui/yamada-components/assets/83833293/7107ba01-5620-4d82-bf59-bffd9bbf59e7">


## Is this a breaking change (Yes/No):

No

## Additional Information
None