### PR TITLE
fix(component-card): fixed `z-index` of component-card

### DIFF
--- a/components/data-display/component-card.tsx
+++ b/components/data-display/component-card.tsx
@@ -142,7 +142,6 @@ const ViewModeControl: FC<ViewModeControlProps> = memo(
         minW={{ base: "xs", md: "auto" }}
         defaultValue="preview"
         onChange={(mode) => modeRef.current(mode as Mode)}
-        z="0"
         {...rest}
       >
         <SegmentedControlButton value="preview">
@@ -184,6 +183,7 @@ const ComponentCardBody: FC<ComponentCardBodyProps> = memo(
           paths={paths}
           containerProps={metadata?.options?.container}
           display={mode === "preview" ? "flex" : "none"}
+          z="1"
         />
         <ComponentCodePreview
           components={components}

--- a/components/data-display/component-card.tsx
+++ b/components/data-display/component-card.tsx
@@ -76,7 +76,7 @@ export const ComponentCard = memo(
               </HStack>
             </HStack>
 
-            <HStack gap="sm">
+            <HStack gap="sm" z="0">
               <IconButton
                 aria-label="Download the files"
                 variant="outline"

--- a/components/data-display/component-card.tsx
+++ b/components/data-display/component-card.tsx
@@ -142,6 +142,7 @@ const ViewModeControl: FC<ViewModeControlProps> = memo(
         minW={{ base: "xs", md: "auto" }}
         defaultValue="preview"
         onChange={(mode) => modeRef.current(mode as Mode)}
+        z="0"
         {...rest}
       >
         <SegmentedControlButton value="preview">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #262

## Description

This fixes `z-index` of `component card` which made overlays in component preview overlap.

## Is this a breaking change (Yes/No):

No