### PR TITLE
feat(texts): added reveal on scroll `text` example

### DIFF
--- a/contents/typography/texts/on-scroll/index.tsx
+++ b/contents/typography/texts/on-scroll/index.tsx
@@ -1,9 +1,17 @@
-import { Box, ScrollArea, Text } from "@yamada-ui/react"
-import { useState, useRef, type FC } from "react"
+import { Flex, ScrollArea, Text } from "@yamada-ui/react"
+import { useState, useRef, type FC, useEffect } from "react"
 
 const OnScroll: FC = () => {
   const [scrollTop, setScrollTop] = useState(0)
+  const maxScrollTop = useRef(0)
   const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (contentRef.current) {
+      maxScrollTop.current =
+        contentRef.current.scrollHeight - contentRef.current.clientHeight
+    }
+  }, [])
 
   const text =
     "Yamada UI is a versatile React component library, unleashing the power of your application's animation and flexibility. It provides an intuitive and efficient way to integrate advanced styling into your application, bringing your ideas to life."
@@ -12,23 +20,24 @@ const OnScroll: FC = () => {
     <ScrollArea
       onScrollPositionChange={({ y }) => {
         if (contentRef.current) {
-          const maxScrollTop =
-            contentRef.current.scrollHeight - contentRef.current.clientHeight
-          setScrollTop((y / maxScrollTop) * text.length)
+          setScrollTop((y / maxScrollTop.current) * text.length)
         }
       }}
       maxH="lg"
       type="always"
       ref={contentRef}
+      w="full"
     >
-      <Box minH="xl" h="100vh">
+      <Flex justifyContent="center" minH="xl" h="100vh" position="relative">
         <Text
           position="fixed"
-          top="0"
           pt="md"
           bgGradient="linear(to-l, #7928CA, #FF0080)"
           bgClip="text"
           fontWeight="semibold"
+          maxW="xl"
+          textAlign="center"
+          z="-1"
         >
           {text.split("").map((char, index) => (
             <Text
@@ -41,7 +50,7 @@ const OnScroll: FC = () => {
             </Text>
           ))}
         </Text>
-      </Box>
+      </Flex>
     </ScrollArea>
   )
 }

--- a/contents/typography/texts/on-scroll/index.tsx
+++ b/contents/typography/texts/on-scroll/index.tsx
@@ -1,0 +1,49 @@
+import { Box, ScrollArea, Text } from "@yamada-ui/react"
+import { useState, useRef, type FC } from "react"
+
+const OnScroll: FC = () => {
+  const [scrollTop, setScrollTop] = useState(0)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const text =
+    "Yamada UI is a versatile React component library, unleashing the power of your application's animation and flexibility. It provides an intuitive and efficient way to integrate advanced styling into your application, bringing your ideas to life."
+
+  return (
+    <ScrollArea
+      onScrollPositionChange={({ y }) => {
+        if (contentRef.current) {
+          const maxScrollTop =
+            contentRef.current.scrollHeight - contentRef.current.clientHeight
+          setScrollTop((y / maxScrollTop) * text.length)
+        }
+      }}
+      maxH="lg"
+      type="always"
+      ref={contentRef}
+    >
+      <Box minH="xl" h="100vh">
+        <Text
+          position="fixed"
+          top="0"
+          pt="md"
+          bgGradient="linear(to-l, #7928CA, #FF0080)"
+          bgClip="text"
+          fontWeight="semibold"
+        >
+          {text.split("").map((char, index) => (
+            <Text
+              as="span"
+              key={index}
+              opacity={scrollTop <= index ? "0.8" : undefined}
+              color={scrollTop <= index ? ["black", "white"] : undefined}
+            >
+              {char}
+            </Text>
+          ))}
+        </Text>
+      </Box>
+    </ScrollArea>
+  )
+}
+
+export default OnScroll

--- a/contents/typography/texts/on-scroll/metadata.json
+++ b/contents/typography/texts/on-scroll/metadata.json
@@ -1,0 +1,15 @@
+{
+  "en": {
+    "title": "Reveal Text on Scroll",
+    "description": "This example shows how you can reveal text on scroll."
+  },
+  "ja": {
+    "title": "スクロールしたときにテキストを表示する",
+    "description": "この例では、スクロールしたときにテキストを表示する方法を示しています。"
+  },
+  "options": {
+    "container": {
+      "centerContent": true
+    }
+  }
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #150

## Description

This adds a `text` component example that reveal on scroll.

## Is this a breaking change (Yes/No):

No

## Additional Information

This may be performance heavy, and could potentially be improved.