### PR TITLE
refactor(header): removed `useBreakpointValue`

### DIFF
--- a/contents/layouts/headers/with-tabs/index.tsx
+++ b/contents/layouts/headers/with-tabs/index.tsx
@@ -22,11 +22,10 @@ import {
   MenuItem,
   MenuList,
   Tab,
+  TabList,
   TabPanels,
   Tabs,
-  type TabsProps,
   Text,
-  useBreakpointValue,
   VStack,
 } from "@yamada-ui/react"
 import { useState, type FC } from "react"
@@ -44,11 +43,6 @@ const tabs = [
 
 const WithTabs: FC = () => {
   const [active, setActive] = useState<number>(0)
-
-  const orientation = useBreakpointValue<TabsProps["orientation"]>({
-    base: "horizontal",
-    md: "vertical",
-  })
 
   return (
     <Flex
@@ -122,26 +116,28 @@ const WithTabs: FC = () => {
           variant="unstyled"
           onChange={setActive}
           index={active}
-          orientation={orientation}
+          orientation="vertical"
           justifyContent={{ base: "center", md: "flex-end" }}
         >
-          {tabs.map((tab, index) => (
-            <Tab
-              key={tab}
-              value={tab}
-              data-active={active === index || undefined}
-              bg={active === index ? ["white", "black"] : undefined}
-              borderTopLeftRadius="md"
-              borderTopRightRadius={{ base: "md", md: "none" }}
-              borderBottomLeftRadius={{ base: "none", md: "md" }}
-              fontWeight="semibold"
-              as="a"
-              href={`/${tab.toLocaleLowerCase()}`}
-              onClick={(e) => e.preventDefault()}
-            >
-              {tab}
-            </Tab>
-          ))}
+          <TabList flexDir={{ base: "row", md: "column" }}>
+            {tabs.map((tab, index) => (
+              <Tab
+                key={tab}
+                value={tab}
+                data-active={active === index || undefined}
+                bg={active === index ? ["white", "black"] : undefined}
+                borderTopLeftRadius="md"
+                borderTopRightRadius={{ base: "md", md: "none" }}
+                borderBottomLeftRadius={{ base: "none", md: "md" }}
+                fontWeight="semibold"
+                as="a"
+                href={`/${tab.toLocaleLowerCase()}`}
+                onClick={(e) => e.preventDefault()}
+              >
+                {tab}
+              </Tab>
+            ))}
+          </TabList>
           <TabPanels display="none" />
         </Tabs>
       </VStack>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #274

## Description

Removed `useBreakpointValue`.

## Current behavior (updates)

We were using `useBreakpointValue`.

## New behavior

I have changed it to implement changing the orientation of tabs using alternative method.

## Is this a breaking change (Yes/No):

No