### PR TITLE
fix(path): fixed `theme` and `config` path having `\\` instead of `/`

### DIFF
--- a/utils/component.ts
+++ b/utils/component.ts
@@ -140,13 +140,13 @@ export const getComponent =
       const name = slug.split("/").at(-1)!
       const dirPath = path.join("contents", slug)
       const componentPath = path.join(dirPath, "index.tsx")
-      const themePath = path.join(dirPath, "theme.ts")
-      const configPath = path.join(dirPath, "config.ts")
+      const themePath = path.join(dirPath, "theme.ts").replace(/\\/g, "/")
+      const configPath = path.join(dirPath, "config.ts").replace(/\\/g, "/")
       const validComponentPath = path
         .join(slug, "index.tsx")
         .replace(/\\/g, "/")
-      const validThemePath = path.join(slug, "theme.ts")
-      const validConfigPath = path.join(slug, "config.ts")
+      const validThemePath = path.join(slug, "theme.ts").replace(/\\/g, "/")
+      const validConfigPath = path.join(slug, "config.ts").replace(/\\/g, "/")
 
       if (!existsSync(componentPath)) return undefined
 

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -140,8 +140,8 @@ export const getComponent =
       const name = slug.split("/").at(-1)!
       const dirPath = path.join("contents", slug)
       const componentPath = path.join(dirPath, "index.tsx")
-      const themePath = path.join(dirPath, "theme.ts").replace(/\\/g, "/")
-      const configPath = path.join(dirPath, "config.ts").replace(/\\/g, "/")
+      const themePath = path.join(dirPath, "theme.ts")
+      const configPath = path.join(dirPath, "config.ts")
       const validComponentPath = path
         .join(slug, "index.tsx")
         .replace(/\\/g, "/")


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #276

## Description

Fixed `theme` and `config` not working on Windows.

## Current behavior (updates)

`path.join` joins path with `\\`.

## New behavior

The paths are now joined with `/`.

## Is this a breaking change (Yes/No):

No