### PR TITLE
refactor(comments): replaced `comments` example to be responsive using `breakpoints`

### DIFF
--- a/contents/data-display/comments/comment/index.tsx
+++ b/contents/data-display/comments/comment/index.tsx
@@ -6,25 +6,20 @@ export const Comment: FC = () => {
     <Card variant="unstyled" maxW="md">
       <CardBody>
         <Grid
-          templateAreas={`
-            "avatar user empty"
-            "avatar content content"
-          `}
-          gap="sm"
-          _container={[
-            {
-              maxW: "300px",
-              css: {
-                gridTemplateAreas: `
+          templateAreas={{
+            base: `
+                  "avatar user empty"
+                  "avatar content content"
+                `,
+            md: `
                   "avatar user empty"
                   "content content content"
                 `,
-                placeItems: "center",
-              },
-            },
-          ]}
+          }}
+          gap="sm"
+          placeItems={{ base: "start", md: "center" }}
         >
-          <GridItem area="avatar">
+          <GridItem area="avatar" pr={{ base: "sm", md: "xs" }}>
             <Avatar src="https://avatars.githubusercontent.com/u/61367823?v=4" />
           </GridItem>
           <GridItem area="user">

--- a/contents/data-display/comments/comment/index.tsx
+++ b/contents/data-display/comments/comment/index.tsx
@@ -11,15 +11,15 @@ export const Comment: FC = () => {
                   "avatar user empty"
                   "avatar content content"
                 `,
-            md: `
+            sm: `
                   "avatar user empty"
                   "content content content"
                 `,
           }}
           gap="sm"
-          placeItems={{ base: "start", md: "center" }}
+          placeItems={{ base: "start", sm: "center" }}
         >
-          <GridItem area="avatar" pr={{ base: "sm", md: "xs" }}>
+          <GridItem area="avatar" pr={{ base: "sm", sm: "xs" }}>
             <Avatar src="https://avatars.githubusercontent.com/u/61367823?v=4" />
           </GridItem>
           <GridItem area="user">

--- a/contents/data-display/comments/with-html-content/index.tsx
+++ b/contents/data-display/comments/with-html-content/index.tsx
@@ -14,29 +14,20 @@ export const CommentWithHTMLContent: FC = () => {
     <Card variant="outline" maxW="md">
       <CardBody>
         <Grid
-          templateAreas={`
-            "avatar user empty"
-            "avatar content content"
-          `}
-          gap="sm"
-          _container={[
-            {
-              maxW: "300px",
-              css: {
-                gridTemplateAreas: `
+          templateAreas={{
+            base: `
+                  "avatar user empty"
+                  "avatar content content"
+                `,
+            md: `
                   "avatar user empty"
                   "content content content"
                 `,
-                placeItems: "center",
-              },
-            },
-          ]}
+          }}
+          gap="sm"
+          placeItems={{ base: "start", md: "center" }}
         >
-          <GridItem
-            area="avatar"
-            pr="sm"
-            _container={[{ maxW: "300px", css: { pr: "xs" } }]}
-          >
+          <GridItem area="avatar" pr={{ base: "sm", md: "xs" }}>
             <Avatar src="https://avatars.githubusercontent.com/u/61367823?v=4" />
           </GridItem>
           <GridItem area="user" placeItems="center">

--- a/contents/data-display/comments/with-html-content/index.tsx
+++ b/contents/data-display/comments/with-html-content/index.tsx
@@ -19,15 +19,15 @@ export const CommentWithHTMLContent: FC = () => {
                   "avatar user empty"
                   "avatar content content"
                 `,
-            md: `
+            sm: `
                   "avatar user empty"
                   "content content content"
                 `,
           }}
           gap="sm"
-          placeItems={{ base: "start", md: "center" }}
+          placeItems={{ base: "start", sm: "center" }}
         >
-          <GridItem area="avatar" pr={{ base: "sm", md: "xs" }}>
+          <GridItem area="avatar" pr={{ base: "sm", sm: "xs" }}>
             <Avatar src="https://avatars.githubusercontent.com/u/61367823?v=4" />
           </GridItem>
           <GridItem area="user" placeItems="center">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #317

## Description

I have replaced `_container` with Yamada UI breakpoints.

## Current behavior (updates)

The example was using `_container` to make it responsive.

## New behavior

I have changed to use Yamada UI breakpoints such as `sm` to be responsive.

## Is this a breaking change (Yes/No):

No