### PR TITLE
fix(pagination): resolve nested button issue in pagination component

### DIFF
--- a/contents/navigation/paginations/simple-button/index.tsx
+++ b/contents/navigation/paginations/simple-button/index.tsx
@@ -1,10 +1,11 @@
+import type { HTMLUIProps } from "@yamada-ui/react"
 import { Box, Pagination, Text, ui } from "@yamada-ui/react"
 import { useState, type FC } from "react"
 
 const SimpleButton: FC = () => {
   const [page, onChange] = useState<number>(1)
 
-  const buttonStyles = {
+  const buttonStyles: HTMLUIProps<"button"> = {
     p: "sm",
     w: 20,
     display: "flex",

--- a/contents/navigation/paginations/simple-button/index.tsx
+++ b/contents/navigation/paginations/simple-button/index.tsx
@@ -1,8 +1,15 @@
-import { Box, Button, Pagination, Text, ui } from "@yamada-ui/react"
+import { Box, Pagination, Text, ui } from "@yamada-ui/react"
 import { useState, type FC } from "react"
 
 const SimpleButton: FC = () => {
   const [page, onChange] = useState<number>(1)
+
+  const buttonStyles = {
+    p: "sm",
+    w: 20,
+    display: "flex",
+    justifyContent: "center",
+  }
 
   return (
     <Box>
@@ -13,18 +20,12 @@ const SimpleButton: FC = () => {
         justifyContent="center"
         innerProps={{ display: "none" }}
         controlPrevProps={{
-          children: (
-            <Button variant="ghost" size="sm">
-              Prev
-            </Button>
-          ),
+          children: "Prev",
+          ...buttonStyles,
         }}
         controlNextProps={{
-          children: (
-            <Button variant="ghost" size="sm">
-              Next
-            </Button>
-          ),
+          children: "Next",
+          ...buttonStyles,
         }}
       />
       <Text


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #516 <!-- Github issue # here -->

## Description

Fixes the issue of nested buttons in the pagination component by refactoring the button rendering logic. The `controlPrevProps` and `controlNextProps` were updated to remove the nesting and ensure styling consistency.

## Current behavior (updates)

The `Pagination` component currently renders buttons with nested button elements, which is semantically incorrect and causes issues with the UI.

## New behavior

The pagination buttons now render with text only (e.g., "Prev" and "Next"), and all styling is applied directly to the buttons themselves. This removes the nested button structure and ensures that the buttons are styled correctly while maintaining the same appearance.

## Is this a breaking change (Yes/No):

No

## Additional Information

None
