### PR TITLE
refactor(component-preview): removed default `height` prop from `containerProps`

### DIFF
--- a/components/data-display/component-preview.tsx
+++ b/components/data-display/component-preview.tsx
@@ -147,7 +147,6 @@ export const ComponentPreview = memo(
 
         let props: HTMLUIProps = {
           containerType: "inline-size",
-          h: "full",
           overflow: "auto",
           w: "full",
           ...rest,
@@ -165,7 +164,6 @@ export const ComponentPreview = memo(
         if (isFullHeight) {
           props = {
             ...props,
-            h: "full",
             minH: "full",
           }
         }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #536

## Description

I have fixed the issue with demo overflowing the preview.

## Current behavior (updates)

The demo content overflowed vertically due to `h="full"`.

## New behavior

I ave removed height from the default container props.

## Is this a breaking change (Yes/No):

Possible

## Additional Information

I have checked the other components, but please also double check if the examples are not breaking.