### PR TITLE
Added `ignore` option when adding new components

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -47,7 +47,7 @@ cd yamada-components
   - コンポーネント名はケバブケースで入力してください。
   - [theme](https://yamada-ui.com/ja/styled-system/theming)が`true`の場合、コンポーネントにカスタマイズしたテーマを適用します。
   - [config](https://yamada-ui.com/ja/styled-system/configure)が`true`の場合、コンポーネントにカスタマイズしたコンフィグを適用します。
-  - **`ignore`** が`true`の場合、コンポーネントを非表示にします。
+  - **`ignore`** が`true`の場合、コンポーネントはサイト上でのレンダリングから除外されます。
 
 ## プルリクエストを作成しますか？
 

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -47,6 +47,7 @@ cd yamada-components
   - コンポーネント名はケバブケースで入力してください。
   - [theme](https://yamada-ui.com/ja/styled-system/theming)が`true`の場合、コンポーネントにカスタマイズしたテーマを適用します。
   - [config](https://yamada-ui.com/ja/styled-system/configure)が`true`の場合、コンポーネントにカスタマイズしたコンフィグを適用します。
+  - **`ignore`** が`true`の場合、コンポーネントを非表示にします。
 
 ## プルリクエストを作成しますか？
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ To improve our development process, we have set up tools and systems.
   - Please enter the component name in kebab-case.
   - If [theme](https://yamada-ui.com/styled-system/theming) is `true`, a customized theme will be applied to the component.
   - If [config](https://yamada-ui.com/styled-system/configure) is `true`, a customized config will be applied to the component.
+  - If **`ignore`** is `true`, a component will be ignored on the site.
 
 ## Making a Pull Request?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ To improve our development process, we have set up tools and systems.
   - Please enter the component name in kebab-case.
   - If [theme](https://yamada-ui.com/styled-system/theming) is `true`, a customized theme will be applied to the component.
   - If [config](https://yamada-ui.com/styled-system/configure) is `true`, a customized config will be applied to the component.
-  - If **`ignore`** is `true`, a component will be ignored on the site.
+  - When **`ignore`** is set to `true`, the component will be excluded from being rendered on the site.
 
 ## Making a Pull Request?
 

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -245,7 +245,7 @@ export default function plop(
         type: "list",
         name: "ignore",
         choices: ["Yes", "No"],
-        default: "Yes",
+        default: "No",
         message: "Does this component need to be ignored?:",
       },
     ],

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -241,6 +241,13 @@ export default function plop(
         default: "No",
         message: "Does this component need a config?:",
       },
+      {
+        type: "list",
+        name: "ignore",
+        choices: ["Yes", "No"],
+        default: "Yes",
+        message: "Does this component need to be ignored?:",
+      },
     ],
 
     actions: (answers) => {
@@ -248,7 +255,8 @@ export default function plop(
 
       if (!answers) return actions
 
-      const { config, newCategoryGroupName, newCategoryName, theme } = answers
+      const { config, ignore, newCategoryGroupName, newCategoryName, theme } =
+        answers
 
       let destination = `./contents/{{dashCase categoryGroupName}}/{{dashCase categoryName}}/{{dashCase componentName}}`
 
@@ -311,6 +319,15 @@ export default function plop(
           abortOnFail: true,
           destination,
           templateFiles: "plop/optional/config.ts.hbs",
+        })
+      }
+
+      if (ignore === "Yes") {
+        actions.push({
+          type: "append",
+          path: destination + "/metadata.json",
+          pattern: /"options": {/,
+          template: `  "ignore": true,`,
         })
       }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

## Description
### Added `ignore` option when adding new components.
I was frustrated by the need to create a component and then add an `ignore` option to it afterward. This change introduces the `ignore` option by default, without modifying the existing template. If `ignore` is no longer the default in the future, you can simply change the default from `Yes` to `No`.

<!-- Add a brief description. -->

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
No.
<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
* You may reject this change as it is just a suggestion